### PR TITLE
Fix/config path sanitization

### DIFF
--- a/wifi_controller/backend/fileServer.py
+++ b/wifi_controller/backend/fileServer.py
@@ -1,4 +1,5 @@
 import json
+import os
 from os import listdir
 
 from flask import Flask, jsonify, request
@@ -22,7 +23,8 @@ def list_config_files():
 def config_file(file_name):
     if request.method == 'GET':
         try:
-            with open(f'{config_path}/{file_name}', 'r') as f:
+            file_path = os.path.join(config_path, file_name)
+            with open(file_path, 'r') as f:
                 data = f.read()
                 return jsonify({
                     'data': data
@@ -33,7 +35,8 @@ def config_file(file_name):
             }))
     else:
         data = json.loads(request.data.decode())['text']
-        with open(f'{config_path}/{file_name}', 'w') as f:
+        file_path = os.path.join(config_path, file_name)
+        with open(file_path, 'w') as f:
             f.write(data)
         return jsonify({
             'result': 'Successfully update config file'

--- a/wifi_controller/backend/fileServer.py
+++ b/wifi_controller/backend/fileServer.py
@@ -23,7 +23,9 @@ def list_config_files():
 def config_file(file_name):
     if request.method == 'GET':
         try:
-            file_path = os.path.join(config_path, file_name)
+            file_path = os.path.realpath(os.path.join(config_path, file_name))
+            if not file_path.startswith(os.path.realpath(config_path) + os.sep):
+                return jsonify({'error': 'Invalid file name'}), 400
             with open(file_path, 'r') as f:
                 data = f.read()
                 return jsonify({
@@ -35,7 +37,9 @@ def config_file(file_name):
             }))
     else:
         data = json.loads(request.data.decode())['text']
-        file_path = os.path.join(config_path, file_name)
+        file_path = os.path.realpath(os.path.join(config_path, file_name))
+        if not file_path.startswith(os.path.realpath(config_path) + os.sep):
+            return jsonify({'error': 'Invalid file name'}), 400
         with open(file_path, 'w') as f:
             f.write(data)
         return jsonify({


### PR DESCRIPTION
## Summary
- Replace f-string path concatenation with `os.path.join` for config file path construction in `fileServer.py`
- Prevents potential path traversal issues and improves cross-platform compatibility

## Test plan
- [ ] Verify GET requests for config files still work correctly
- [ ] Verify POST/PUT requests for config file updates still work correctly
- [ ] Test with various file names to ensure path construction is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)